### PR TITLE
feat: use MAE algorithm for straight line detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,22 +81,24 @@ If your key type isn't `DefaultUnistrokeNames`, you'll need to call
 which will return a `RecognizedCustomUnistroke<MyKey>` instead of a
 `RecognizedUnistroke`.
 
-
+Also note that straight lines are a special case in the default unistroke templates,
+and aren't available by default with custom unistroke templates.
+To recognize straight lines, see the [Straight lines](#straight-lines) section below.
 
 ```dart
-referenceUnistrokes = <Unistroke<MyUnistrokeNames>>[
-  Unistroke(MyUnistrokeNames.circle, [...]),
-  Unistroke(MyUnistrokeNames.rectangle, [...]),
-  Unistroke(MyUnistrokeNames.triangle, [...]),
-  Unistroke(MyUnistrokeNames.leaf, [...]),
-];
-
 enum MyUnistrokeNames {
   circle,
   rectangle,
   triangle,
   leaf,
 }
+
+referenceUnistrokes = <Unistroke<MyUnistrokeNames>>[
+  Unistroke(MyUnistrokeNames.circle, [...]),
+  Unistroke(MyUnistrokeNames.rectangle, [...]),
+  Unistroke(MyUnistrokeNames.triangle, [...]),
+  Unistroke(MyUnistrokeNames.leaf, [...]),
+];
 
 final recognized = recognizeCustomUnistroke<MyUnistrokeNames>(points);
 ```
@@ -111,6 +113,36 @@ final recognized = recognizeCustomUnistroke<MyUnistrokeNames>(
 ```
 
 You could also set `referenceUnistrokes` to `example$1Unistrokes` to use the templates that were originally defined in the paper, though they're not very pretty and were probably intended to just be a proof-of-concept. (The key type for `example$1Unistrokes` is `String`.)
+
+#### Straight lines
+
+Straight lines are a special case in the default unistroke templates,
+in that they're best recognized by a different algorithm than the other shapes (i.e. not $1).
+
+If you're using `default$1Unistrokes` (the default), you don't need to worry about this, and straight lines will be detected as `DefaultUnistrokeNames.line`.
+
+But if you're using custom unistroke templates, you'll need to specify the `name` of the straight line unistroke template.
+I still recommend that you provide a sensible points list for the line template, but it won't be used for the detection itself.
+
+```dart
+enum MyUnistrokeNames {
+  line,
+  // ...
+}
+
+referenceUnistrokes = <Unistroke<MyUnistrokeNames>>[
+  Unistroke(MyUnistrokeNames.line, [
+    Offset(50, 0),
+    Offset(50, 100),
+  ]),
+  // ...
+];
+
+final recognized = recognizeCustomUnistroke<MyUnistrokeNames>(
+  points,
+  straightLineName: MyUnistrokeNames.line,
+);
+```
 
 ## About the $1 Unistroke Recognizer
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ If your key type isn't `DefaultUnistrokeNames`, you'll need to call
 which will return a `RecognizedCustomUnistroke<MyKey>` instead of a
 `RecognizedUnistroke`.
 
+
+
 ```dart
 referenceUnistrokes = <Unistroke<MyUnistrokeNames>>[
   Unistroke(MyUnistrokeNames.circle, [...]),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,8 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:one_dollar_unistroke_recognizer/one_dollar_unistroke_recognizer.dart';
 import 'package:one_dollar_unistroke_recognizer_example/canvas_draw.dart';
 
-final recognized =
-    ValueNotifier<RecognizedUnistroke?>(null);
+final recognized = ValueNotifier<RecognizedUnistroke?>(null);
 Timer? pointDebounce;
 
 void main() {

--- a/lib/one_dollar_unistroke_recognizer.dart
+++ b/lib/one_dollar_unistroke_recognizer.dart
@@ -87,10 +87,17 @@ RecognizedCustomUnistroke<K>? recognizeUnistrokeOfType<K>(
 /// If you haven't changed [referenceUnistrokes] or
 /// [overrideReferenceUnistrokes], you can call [recognizeUnistroke] instead
 /// so you don't have to specify the type parameter.
+///
+/// If you're using custom unistroke templates,
+/// and you need straight line detection,
+/// please set [straightLineName] to the name of the straight line template.
+/// This is needed since straight lines are best recognized with
+/// a different algorithm than the standard $1 algorithm.
 RecognizedCustomUnistroke<K>? recognizeCustomUnistroke<K>(
   List<Offset> inputPoints, {
   bool useProtractor = true,
   List<Unistroke<K>>? overrideReferenceUnistrokes,
+  K? straightLineName,
 }) {
   // Not enough points to recognize
   if (inputPoints.length < Unistroke.numPoints) return null;
@@ -104,7 +111,8 @@ RecognizedCustomUnistroke<K>? recognizeCustomUnistroke<K>(
   for (final unistrokeTemplate
       in (overrideReferenceUnistrokes ?? referenceUnistrokes)) {
     final double distance;
-    if (unistrokeTemplate.name == DefaultUnistrokeNames.line) {
+    if (unistrokeTemplate.name ==
+        (straightLineName ?? DefaultUnistrokeNames.line)) {
       distance = meanAbsoluteError(
         inputPoints,
         useProtractor: useProtractor,

--- a/lib/one_dollar_unistroke_recognizer.dart
+++ b/lib/one_dollar_unistroke_recognizer.dart
@@ -115,7 +115,6 @@ RecognizedCustomUnistroke<K>? recognizeCustomUnistroke<K>(
         (straightLineName ?? DefaultUnistrokeNames.line)) {
       distance = meanAbsoluteError(
         candidate.points,
-        useProtractor: useProtractor,
       );
     } else if (useProtractor) {
       distance = optimalCosineDistance(

--- a/lib/one_dollar_unistroke_recognizer.dart
+++ b/lib/one_dollar_unistroke_recognizer.dart
@@ -113,9 +113,10 @@ RecognizedCustomUnistroke<K>? recognizeCustomUnistroke<K>(
     final double distance;
     if (unistrokeTemplate.name ==
         (straightLineName ?? DefaultUnistrokeNames.line)) {
-      distance = meanAbsoluteError(
+      final mae = meanAbsoluteError(
         candidate.points,
       );
+      distance = useProtractor ? mae / Unistroke.squareDiagonal : mae;
     } else if (useProtractor) {
       distance = optimalCosineDistance(
         unistrokeTemplate.vector,

--- a/lib/one_dollar_unistroke_recognizer.dart
+++ b/lib/one_dollar_unistroke_recognizer.dart
@@ -3,6 +3,7 @@ library one_dollar_unistroke_recognizer;
 import 'dart:ui' show Offset;
 
 import 'package:one_dollar_unistroke_recognizer/src/default_unistrokes.dart';
+import 'package:one_dollar_unistroke_recognizer/src/line_detection.dart';
 import 'package:one_dollar_unistroke_recognizer/src/recognized_unistroke.dart';
 import 'package:one_dollar_unistroke_recognizer/src/unistroke.dart';
 import 'package:one_dollar_unistroke_recognizer/src/utils.dart';
@@ -102,18 +103,27 @@ RecognizedCustomUnistroke<K>? recognizeCustomUnistroke<K>(
   assert((overrideReferenceUnistrokes ?? referenceUnistrokes).isNotEmpty);
   for (final unistrokeTemplate
       in (overrideReferenceUnistrokes ?? referenceUnistrokes)) {
-    final distance = useProtractor
-        ? optimalCosineDistance(
-            unistrokeTemplate.vector,
-            candidate.vector,
-          )
-        : distanceAtBestAngle(
-            candidate.points,
-            unistrokeTemplate.points,
-            -angleRange,
-            angleRange,
-            anglePrecision,
-          );
+    final double distance;
+    if (unistrokeTemplate.name == DefaultUnistrokeNames.line) {
+      distance = meanAbsoluteError(
+        inputPoints,
+        useProtractor: useProtractor,
+      );
+    } else if (useProtractor) {
+      distance = optimalCosineDistance(
+        unistrokeTemplate.vector,
+        candidate.vector,
+      );
+    } else {
+      distance = distanceAtBestAngle(
+        candidate.points,
+        unistrokeTemplate.points,
+        -angleRange,
+        angleRange,
+        anglePrecision,
+      );
+    }
+
     if (distance < closestUnistrokeDist) {
       closestUnistrokeDist = distance;
       closestUnistroke = unistrokeTemplate;

--- a/lib/one_dollar_unistroke_recognizer.dart
+++ b/lib/one_dollar_unistroke_recognizer.dart
@@ -114,7 +114,7 @@ RecognizedCustomUnistroke<K>? recognizeCustomUnistroke<K>(
     if (unistrokeTemplate.name ==
         (straightLineName ?? DefaultUnistrokeNames.line)) {
       distance = meanAbsoluteError(
-        inputPoints,
+        candidate.points,
         useProtractor: useProtractor,
       );
     } else if (useProtractor) {

--- a/lib/src/default_unistrokes.dart
+++ b/lib/src/default_unistrokes.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'dart:ui' show Offset, Rect;
 
+import 'package:one_dollar_unistroke_recognizer/src/line_detection.dart';
 import 'package:one_dollar_unistroke_recognizer/src/unistroke.dart';
 
 const _circlePoints = 32;
@@ -37,7 +38,12 @@ final default$1Unistrokes =
 
 /// The enum of the names of the default unistrokes.
 enum DefaultUnistrokeNames {
-  /// A line
+  /// A line.
+  ///
+  /// Note that the line unistroke in default$1Unistrokes is just for
+  /// completeness,
+  /// but we use a different algorithm to recognize straight lines:
+  /// see [meanAbsoluteError].
   line,
 
   /// A circle

--- a/lib/src/line_detection.dart
+++ b/lib/src/line_detection.dart
@@ -8,7 +8,10 @@ class Line {
   // ignore: public_member_api_docs
   Line(this.start, this.end);
 
+  /// The start point of the line.
   final Offset start;
+
+  /// The end point of the line.
   final Offset end;
 
   /// The [a] in the equation [ax + by + c = 0].

--- a/lib/src/line_detection.dart
+++ b/lib/src/line_detection.dart
@@ -1,0 +1,39 @@
+import 'dart:ui' show Offset;
+
+class _Line {
+  _Line(this.start, this.end);
+
+  final Offset start;
+  final Offset end;
+
+  late final dx = end.dx - start.dx;
+  late final dy = end.dy - start.dy;
+  late final sqrLength = dx * dx + dy * dy;
+  late final crossProduct = end.dx * start.dy - end.dy * start.dx;
+
+  /// Returns the min distance from a point to this line.
+  double distanceToPoint(Offset point) {
+    return (dy * point.dx - dx * point.dy + crossProduct).abs() / sqrLength;
+  }
+}
+
+/// Returns the mean absolute error between the inputPoints
+/// and the line between the first and last point.
+///
+/// See https://en.m.wikipedia.org/wiki/Mean_absolute_error.
+///
+/// If [useProtractor] is false,
+/// the mean isn't taken, and the sum of the absolute errors is returned.
+/// This is to match the expected output of a Golden Section Search.
+double meanAbsoluteError(
+  List<Offset> inputPoints, {
+  bool useProtractor = true,
+}) {
+  final line = _Line(inputPoints.first, inputPoints.last);
+  final sumAbsoluteError = inputPoints
+      .map((point) => line.distanceToPoint(point))
+      .reduce((a, b) => a + b);
+  return useProtractor
+      ? sumAbsoluteError / inputPoints.length
+      : sumAbsoluteError;
+}

--- a/lib/src/line_detection.dart
+++ b/lib/src/line_detection.dart
@@ -38,19 +38,11 @@ class Line {
 /// and the line between the first and last point.
 ///
 /// See https://en.m.wikipedia.org/wiki/Mean_absolute_error.
-///
-/// If [useProtractor] is false,
-/// the mean isn't taken, and the sum of the absolute errors is returned.
-/// This is to match the expected output of a Golden Section Search.
-double meanAbsoluteError(
-  List<Offset> inputPoints, {
-  bool useProtractor = true,
-}) {
+double meanAbsoluteError(List<Offset> inputPoints) {
   final line = Line(inputPoints.first, inputPoints.last);
   final sumAbsoluteError = inputPoints
       .map((point) => line.distanceToPoint(point))
       .reduce((a, b) => a + b);
-  return useProtractor
-      ? sumAbsoluteError / inputPoints.length
-      : sumAbsoluteError;
+  final meanAbsoluteError = sumAbsoluteError / inputPoints.length;
+  return meanAbsoluteError;
 }

--- a/lib/src/line_detection.dart
+++ b/lib/src/line_detection.dart
@@ -1,19 +1,33 @@
-import 'dart:ui' show Offset;
+import 'dart:math';
 
-class _Line {
-  _Line(this.start, this.end);
+import 'package:flutter/material.dart' show visibleForTesting, Offset;
+
+/// A line between two points.
+@visibleForTesting
+class Line {
+  // ignore: public_member_api_docs
+  Line(this.start, this.end);
 
   final Offset start;
   final Offset end;
 
-  late final dx = end.dx - start.dx;
-  late final dy = end.dy - start.dy;
-  late final sqrLength = dx * dx + dy * dy;
-  late final crossProduct = end.dx * start.dy - end.dy * start.dx;
+  /// The [a] in the equation [ax + by + c = 0].
+  late final a = end.dy - start.dy;
+
+  /// The [b] in the equation [ax + by + c = 0].
+  late final b = start.dx - end.dx;
+
+  /// The [c] in the equation [ax + by + c = 0].
+  late final c = (-a * start.dx) + (-b * start.dy);
+
+  /// The denominator in the equation for the distance from a point to a line.
+  /// See https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line.
+  late final denominator = sqrt(a * a + b * b);
 
   /// Returns the min distance from a point to this line.
+  /// See https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line.
   double distanceToPoint(Offset point) {
-    return (dy * point.dx - dx * point.dy + crossProduct).abs() / sqrLength;
+    return (a * point.dx + b * point.dy + c).abs() / denominator;
   }
 }
 
@@ -29,7 +43,7 @@ double meanAbsoluteError(
   List<Offset> inputPoints, {
   bool useProtractor = true,
 }) {
-  final line = _Line(inputPoints.first, inputPoints.last);
+  final line = Line(inputPoints.first, inputPoints.last);
   final sumAbsoluteError = inputPoints
       .map((point) => line.distanceToPoint(point))
       .reduce((a, b) => a + b);

--- a/test/line_dist_test.dart
+++ b/test/line_dist_test.dart
@@ -1,0 +1,29 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:one_dollar_unistroke_recognizer/src/line_detection.dart';
+
+void main() {
+  group('Line.distanceToPoint', () {
+    test('(0,0) from flat line', () {
+      final line = Line(Offset.zero, const Offset(1, 0));
+      expect(line.distanceToPoint(Offset.zero), 0);
+    });
+    test('(0,1) from flat line', () {
+      final line = Line(Offset.zero, const Offset(1, 0));
+      expect(line.distanceToPoint(const Offset(0, 1)), 1);
+    });
+    test('(3,4) from diagonal line', () {
+      final line = Line(const Offset(3, 3), const Offset(10, 10));
+      final expected = sqrt(2 * 0.5 * 0.5);
+      expect(
+        line.distanceToPoint(const Offset(3, 4)),
+        closeTo(expected, expected / 1000000),
+      );
+    });
+    test('(0,0) from line at x=1', () {
+      final line = Line(const Offset(1, -999), const Offset(1, 999));
+      expect(line.distanceToPoint(Offset.zero), 1);
+    });
+  });
+}


### PR DESCRIPTION
This PR aims to fix https://github.com/saber-notes/saber/issues/1039 where straight lines are incorrectly detected as circles.

e.g. <img src="https://github.com/adil192/one_dollar_unistroke_recognizer/assets/21128619/e31544b4-bbef-4134-960d-c59b17c82ddf" width=400 alt="The demo page with a wobbly line drawn that has been recognized as a circle with score 0.29">

#### Remaining tasks:

- [x] Update README to mention that straight line detection uses a different algorithm
- [x] Update README to mention how to use straight line detection when not using `default$1Unistrokes`
- [x] Fix scribbles being detected as straight lines