### PR TITLE
fix: better recognition of wide and tall rectangles

### DIFF
--- a/lib/src/default_unistrokes.dart
+++ b/lib/src/default_unistrokes.dart
@@ -22,7 +22,7 @@ final default$1Unistrokes =
         50 + 50 * sin(2 * pi * i / _circlePoints),
       ),
   ]),
-  Unistroke(DefaultUnistrokeNames.rectangle, [
+  Unistroke(DefaultUnistrokeNames.rectangle, isCanonical: true, [
     _rectangle.topLeft,
     _rectangle.topRight,
     _rectangle.bottomRight,

--- a/lib/src/default_unistrokes.dart
+++ b/lib/src/default_unistrokes.dart
@@ -6,6 +6,8 @@ import 'package:one_dollar_unistroke_recognizer/src/unistroke.dart';
 
 const _circlePoints = 32;
 const _rectangle = Rect.fromLTWH(0, 0, 50, 50);
+const _rectangleWidth = Rect.fromLTWH(0, 0, 100, 50);
+const _rectangleHeight = Rect.fromLTWH(0, 0, 50, 100);
 
 /// The default unistroke templates provided by this package.
 final default$1Unistrokes =
@@ -33,6 +35,20 @@ final default$1Unistrokes =
     _rectangle.bottomRight,
     _rectangle.bottomLeft,
     _rectangle.topCenter,
+  ]),
+  Unistroke(DefaultUnistrokeNames.rectangle, [
+    _rectangleWidth.topLeft,
+    _rectangleWidth.topRight,
+    _rectangleWidth.bottomRight,
+    _rectangleWidth.bottomLeft,
+    _rectangleWidth.topLeft,
+  ]),
+  Unistroke(DefaultUnistrokeNames.rectangle, [
+    _rectangleHeight.topLeft,
+    _rectangleHeight.topRight,
+    _rectangleHeight.bottomRight,
+    _rectangleHeight.bottomLeft,
+    _rectangleHeight.topLeft,
   ]),
 ]);
 

--- a/lib/src/default_unistrokes.dart
+++ b/lib/src/default_unistrokes.dart
@@ -6,8 +6,7 @@ import 'package:one_dollar_unistroke_recognizer/src/unistroke.dart';
 
 const _circlePoints = 32;
 const _rectangle = Rect.fromLTWH(0, 0, 50, 50);
-const _rectangleWidth = Rect.fromLTWH(0, 0, 100, 50);
-const _rectangleHeight = Rect.fromLTWH(0, 0, 50, 100);
+const _wideRectangle = Rect.fromLTWH(0, 0, 100, 50);
 
 /// The default unistroke templates provided by this package.
 final default$1Unistrokes =
@@ -30,25 +29,18 @@ final default$1Unistrokes =
     _rectangle.bottomLeft,
     _rectangle.topLeft,
   ]),
+  Unistroke(DefaultUnistrokeNames.rectangle, [
+    _wideRectangle.topLeft,
+    _wideRectangle.topRight,
+    _wideRectangle.bottomRight,
+    _wideRectangle.bottomLeft,
+    _wideRectangle.topLeft,
+  ]),
   Unistroke(DefaultUnistrokeNames.triangle, [
     _rectangle.topCenter,
     _rectangle.bottomRight,
     _rectangle.bottomLeft,
     _rectangle.topCenter,
-  ]),
-  Unistroke(DefaultUnistrokeNames.rectangle, [
-    _rectangleWidth.topLeft,
-    _rectangleWidth.topRight,
-    _rectangleWidth.bottomRight,
-    _rectangleWidth.bottomLeft,
-    _rectangleWidth.topLeft,
-  ]),
-  Unistroke(DefaultUnistrokeNames.rectangle, [
-    _rectangleHeight.topLeft,
-    _rectangleHeight.topRight,
-    _rectangleHeight.bottomRight,
-    _rectangleHeight.bottomLeft,
-    _rectangleHeight.topLeft,
   ]),
 ]);
 

--- a/lib/src/default_unistrokes.dart
+++ b/lib/src/default_unistrokes.dart
@@ -5,15 +5,15 @@ import 'package:one_dollar_unistroke_recognizer/src/line_detection.dart';
 import 'package:one_dollar_unistroke_recognizer/src/unistroke.dart';
 
 const _circlePoints = 32;
-const _rectangle = Rect.fromLTWH(0, 0, 50, 50);
-const _wideRectangle = Rect.fromLTWH(0, 0, 100, 50);
+const _square = Rect.fromLTWH(0, 0, 50, 50);
+const _rectangle = Rect.fromLTWH(0, 0, 100, 50);
 
 /// The default unistroke templates provided by this package.
 final default$1Unistrokes =
     List<Unistroke<DefaultUnistrokeNames>>.unmodifiable([
   Unistroke(DefaultUnistrokeNames.line, [
-    _rectangle.centerLeft,
-    _rectangle.centerRight,
+    _square.centerLeft,
+    _square.centerRight,
   ]),
   Unistroke(DefaultUnistrokeNames.circle, [
     for (var i = 0; i <= _circlePoints; i++)
@@ -23,24 +23,24 @@ final default$1Unistrokes =
       ),
   ]),
   Unistroke(DefaultUnistrokeNames.rectangle, isCanonical: true, [
+    _square.topLeft,
+    _square.topRight,
+    _square.bottomRight,
+    _square.bottomLeft,
+    _square.topLeft,
+  ]),
+  Unistroke(DefaultUnistrokeNames.rectangle, [
     _rectangle.topLeft,
     _rectangle.topRight,
     _rectangle.bottomRight,
     _rectangle.bottomLeft,
     _rectangle.topLeft,
   ]),
-  Unistroke(DefaultUnistrokeNames.rectangle, [
-    _wideRectangle.topLeft,
-    _wideRectangle.topRight,
-    _wideRectangle.bottomRight,
-    _wideRectangle.bottomLeft,
-    _wideRectangle.topLeft,
-  ]),
   Unistroke(DefaultUnistrokeNames.triangle, [
-    _rectangle.topCenter,
-    _rectangle.bottomRight,
-    _rectangle.bottomLeft,
-    _rectangle.topCenter,
+    _square.topCenter,
+    _square.bottomRight,
+    _square.bottomLeft,
+    _square.topCenter,
   ]),
 ]);
 


### PR DESCRIPTION
Added rectangles which are wide and tall to enable better recognition of rectangles which are far from square.

This avoids to recognize circle as the best shape when wide rectangle is drawn.